### PR TITLE
Add TorchLens Chrome extension prototype

### DIFF
--- a/tools/torchlens_extension/README.md
+++ b/tools/torchlens_extension/README.md
@@ -1,0 +1,17 @@
+# TorchLens Chrome Extension
+
+This prototype Chrome extension augments browsing the PyTorch GitHub
+repository with helpful tooling:
+
+1. **Smart Code Summaries** – Hover over files, functions, or classes to
+   retrieve cached GPT powered summaries from a backend API.
+2. **Semantic Navigation** – Ctrl+Click a symbol to jump to its definition
+   across the repo using a static analysis index.
+3. **Live Trace Visualizer** – For traced model files (e.g. from `torch.fx`)
+   a `Visualize Graph` button renders an interactive graph using D3.js.
+4. **PR Intelligence Panel** – Pull request pages show diff summaries,
+   suggested tests, and review questions from an LLM agent.
+5. **Doc ↔ Code Bridge** – Links from API docs lead directly to
+   implementation and code pages surface their related docs.
+
+This directory only contains a simplified prototype for experimentation.

--- a/tools/torchlens_extension/background.js
+++ b/tools/torchlens_extension/background.js
@@ -1,0 +1,4 @@
+// Placeholder background worker for TorchLens extension.
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('TorchLens background loaded');
+});

--- a/tools/torchlens_extension/content.js
+++ b/tools/torchlens_extension/content.js
@@ -1,0 +1,73 @@
+// Simplified content script implementing core behaviors.
+
+function showTooltip(element, text) {
+  const tip = document.createElement('div');
+  tip.className = 'torchlens-tooltip';
+  tip.textContent = text;
+  tip.style.position = 'absolute';
+  tip.style.background = '#ffc';
+  tip.style.border = '1px solid #ccc';
+  tip.style.padding = '2px 4px';
+  tip.style.zIndex = 10000;
+  document.body.appendChild(tip);
+  const rect = element.getBoundingClientRect();
+  tip.style.left = rect.right + 'px';
+  tip.style.top = rect.top + 'px';
+  element.addEventListener('mouseleave', () => tip.remove(), {once: true});
+}
+
+// Fetch summary from backend placeholder
+async function fetchSummary(symbol) {
+  // In real implementation this calls backend API.
+  return `Summary for ${symbol}`;
+}
+
+// Hover handler for summaries
+function handleHover(event) {
+  const target = event.target;
+  if (!target || !target.textContent) return;
+  fetchSummary(target.textContent.trim()).then(text => showTooltip(target, text));
+}
+
+document.addEventListener('mouseover', handleHover);
+
+// Ctrl+Click navigation placeholder
+function handleClick(event) {
+  if (event.ctrlKey) {
+    const symbol = event.target.textContent.trim();
+    // Real implementation would look up symbol location
+    console.log('Navigate to definition of', symbol);
+  }
+}
+
+document.addEventListener('click', handleClick);
+
+// Inject graph visualization button on traced model pages
+function maybeAddGraphButton() {
+  if (document.querySelector('.torchlens-graph-btn')) return;
+  if (!document.body.innerText.includes('torch.fx')) return;
+  const btn = document.createElement('button');
+  btn.textContent = 'Visualize Graph';
+  btn.className = 'torchlens-graph-btn';
+  btn.style.position = 'fixed';
+  btn.style.bottom = '20px';
+  btn.style.right = '20px';
+  btn.onclick = () => alert('Graph visualization would appear');
+  document.body.appendChild(btn);
+}
+
+document.addEventListener('DOMContentLoaded', maybeAddGraphButton);
+
+// PR insights panel placeholder
+function injectPrInsights() {
+  if (!location.pathname.includes('/pull/')) return;
+  const panel = document.createElement('div');
+  panel.textContent = 'PR insights would be shown here';
+  panel.style.background = '#eef';
+  panel.style.padding = '4px';
+  panel.style.marginBottom = '8px';
+  const container = document.querySelector('#discussion_bucket');
+  if (container) container.prepend(panel);
+}
+
+document.addEventListener('DOMContentLoaded', injectPrInsights);

--- a/tools/torchlens_extension/manifest.json
+++ b/tools/torchlens_extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "TorchLens",
+  "description": "Explore the PyTorch repo with smart summaries and navigation",
+  "version": "0.1",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["https://github.com/pytorch/*"],
+  "background": {"service_worker": "background.js"},
+  "content_scripts": [
+    {
+      "matches": ["https://github.com/pytorch/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "TorchLens"
+  }
+}

--- a/tools/torchlens_extension/popup.html
+++ b/tools/torchlens_extension/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      body { font-family: sans-serif; min-width: 200px; }
+    </style>
+  </head>
+  <body>
+    <h3>TorchLens</h3>
+    <p>Extension active.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- document TorchLens extension and its capabilities
- add extension manifest
- implement placeholder content script, background worker, and popup UI

## Testing
- `git status --short`
